### PR TITLE
Improve mod compatability by using isShield() instead of instanceof check

### DIFF
--- a/src/main/java/com/theishiopian/parrying/Enchantment/BashingEnchantment.java
+++ b/src/main/java/com/theishiopian/parrying/Enchantment/BashingEnchantment.java
@@ -5,7 +5,6 @@ import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentType;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ShieldItem;
 
 public class BashingEnchantment extends Enchantment
 {
@@ -34,7 +33,7 @@ public class BashingEnchantment extends Enchantment
 
     public boolean canEnchant(ItemStack p_92089_1_)
     {
-        return p_92089_1_.getItem() instanceof ShieldItem && Config.bashingEnchantEnabled.get();
+        return p_92089_1_.isShield(null) && Config.bashingEnchantEnabled.get();
     }
 
     public boolean canApplyAtEnchantingTable(ItemStack p_92089_1_)

--- a/src/main/java/com/theishiopian/parrying/Mechanics/Bashing.java
+++ b/src/main/java/com/theishiopian/parrying/Mechanics/Bashing.java
@@ -10,7 +10,6 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.ShieldItem;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.Hand;
@@ -39,12 +38,12 @@ public abstract class Bashing
                 ItemStack off = player.getOffhandItem();
                 ItemStack shield = null;
                 Hand hand = Hand.OFF_HAND;
-                if(main.getItem() instanceof ShieldItem)
+                if(main.isShield(player))
                 {
                     shield = main;
                     hand = Hand.MAIN_HAND;
                 }
-                else if(off.getItem() instanceof ShieldItem)
+                else if(off.isShield(player))
                 {
                     shield = off;
                     hand = Hand.OFF_HAND;


### PR DESCRIPTION
I saw a comment on CurseForge that mentioned that shields from the Tetra mod can not use shield bashing. This pull request fixes that :)