### PR TITLE
Check capability before unchecked cast

### DIFF
--- a/src/main/java/com/theishiopian/parrying/Items/QuiverItem.java
+++ b/src/main/java/com/theishiopian/parrying/Items/QuiverItem.java
@@ -36,10 +36,9 @@ import net.minecraft.world.level.block.LayeredCauldronBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.LootTable;
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
+import net.minecraftforge.common.capabilities.*;
 import net.minecraftforge.common.util.INBTSerializable;
+import net.minecraftforge.common.util.Lazy;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
@@ -48,6 +47,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.function.Supplier;
 
 public class QuiverItem extends Item implements DyeableLeatherItem
 {
@@ -408,6 +408,7 @@ public class QuiverItem extends Item implements DyeableLeatherItem
         public QuiverCapability()
         {
             super();
+
         }
 
         public int GetItemCount()
@@ -471,12 +472,13 @@ public class QuiverItem extends Item implements DyeableLeatherItem
         }
 
         private final LazyOptional<QuiverCapability> quiverCapabilityLazyOptional = constantOptional(this);
+        private static final Supplier<Capability<QuiverCapability>> instanceSupplier = () -> CapabilityManager.get(new CapabilityToken<>(){});
 
         @Nonnull
         @Override
         public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction facing)
         {
-            return quiverCapabilityLazyOptional.cast();
+            return capability.orEmpty(instanceSupplier.get(), quiverCapabilityLazyOptional.cast()).cast();
         }
     }
 }

--- a/src/main/java/com/theishiopian/parrying/Items/ScabbardItem.java
+++ b/src/main/java/com/theishiopian/parrying/Items/ScabbardItem.java
@@ -34,9 +34,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.loot.LootContext;
 import net.minecraft.world.level.storage.loot.LootTable;
 import net.minecraft.world.phys.Vec3;
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.common.capabilities.RegisterCapabilitiesEvent;
+import net.minecraftforge.common.capabilities.*;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.CapabilityItemHandler;
@@ -46,6 +44,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.function.Supplier;
 
 public class ScabbardItem extends Item implements DyeableLeatherItem
 {
@@ -393,12 +392,13 @@ public class ScabbardItem extends Item implements DyeableLeatherItem
         }
 
         private final LazyOptional<ScabbardCapability> scabbardCapabilityLazyOptional = constantOptional(this);
+        private static final Supplier<Capability<ScabbardCapability>> instanceSupplier = () -> CapabilityManager.get(new CapabilityToken<>(){});
 
         @Nonnull
         @Override
         public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> capability, @Nullable Direction facing)
         {
-            return scabbardCapabilityLazyOptional.cast();
+            return capability.orEmpty(instanceSupplier.get(), scabbardCapabilityLazyOptional.cast()).cast();
         }
     }
 }


### PR DESCRIPTION
Fixes #30, #31, #33, and https://github.com/ferriarnus/Unidentified-Enchantments/issues/16.

The main way capabilities function are by trusting the capability itself with its own type. The type you choose for the capability is cast to `Capability<C>` upon registration, but you are nevertheless in control of the entire capability and its usage yourself, as long as you implement the required interfaces at minimum. Therefore, doing reckless unchecked casting on overriding `getCapability()` is going to cause problems because of the way capabilities work.

Your capabilities look good and work great, but make sure to watch for little nuances like these. There's also a bit of repetitive code between the Quiver and Scabbard capabilities that could be better isolated into a single class/interface file (for example, I made `CapabilityProvider` and `IPersistentCapability` in ForageCraft 1.17 for this purpose). Also note the usage of `CapabilityManager.get()` in order to get active capabilities from the game, rather than the now deleted `@CapabilityInject` annotation.