### PR TITLE
Isolate coremod conditional logic

### DIFF
--- a/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ArmorMaterialsMixin.java
+++ b/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ArmorMaterialsMixin.java
@@ -1,4 +1,4 @@
-package com.theishiopian.parrying.Mixin;
+package com.theishiopian.parrying.CoreMod.Mixin;
 
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.ArmorMaterials;

--- a/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ArrowMixin.java
+++ b/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ArrowMixin.java
@@ -1,4 +1,4 @@
-package com.theishiopian.parrying.Mixin;
+package com.theishiopian.parrying.CoreMod.Mixin;
 
 import net.minecraft.world.entity.projectile.AbstractArrow;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ItemInHandRendererMixin.java
+++ b/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ItemInHandRendererMixin.java
@@ -1,4 +1,4 @@
-package com.theishiopian.parrying.Mixin;
+package com.theishiopian.parrying.CoreMod.Mixin;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.theishiopian.parrying.Mechanics.DualWieldingMechanic;

--- a/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ParryingMixinPlugin.java
+++ b/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/ParryingMixinPlugin.java
@@ -1,4 +1,4 @@
-package com.theishiopian.parrying.Mixin;
+package com.theishiopian.parrying.CoreMod.Mixin;
 
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.loading.FMLEnvironment;

--- a/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/PlayerMixin.java
+++ b/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/PlayerMixin.java
@@ -1,0 +1,34 @@
+package com.theishiopian.parrying.CoreMod.Mixin;
+
+import com.theishiopian.parrying.Config.Config;
+import com.theishiopian.parrying.CoreMod.Hooks.PlayerHooks;
+import com.theishiopian.parrying.Items.ScopedCrossbow;
+import com.theishiopian.parrying.Mechanics.DualWieldingMechanic;
+import com.theishiopian.parrying.Registration.ModItems;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Optional;
+
+@Mixin(Player.class)
+public class PlayerMixin
+{
+    @Inject(at = @At("HEAD"), method = "getCurrentItemAttackStrengthDelay", cancellable = true)
+    private void InjectIntoGetCurrentItemAttackStrengthDelay(CallbackInfoReturnable<Float> cir)
+    {
+        Optional<Float> value = PlayerHooks.ModifyAttackStrength((Player) (Object) this);
+        value.ifPresent(cir::setReturnValue);
+    }
+
+    @Inject(at = @At("HEAD"), method = "isScoping", cancellable = true)
+    private void InjectIntoIsScoping(CallbackInfoReturnable<Boolean> cir)
+    {
+        Optional<Boolean> value = PlayerHooks.ModifyScopingStatus((Player) (Object) this);
+        value.ifPresent(cir::setReturnValue);
+    }
+}

--- a/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/TiersMixin.java
+++ b/src/main/java/com/theishiopian/parrying/CoreMod/Mixin/TiersMixin.java
@@ -1,4 +1,4 @@
-package com.theishiopian.parrying.Mixin;
+package com.theishiopian.parrying.CoreMod.Mixin;
 
 import net.minecraft.world.item.Tiers;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/resources/parrying.mixins.json
+++ b/src/main/resources/parrying.mixins.json
@@ -1,11 +1,11 @@
 {
   "required": true,
-  "package": "com.theishiopian.parrying.Mixin",
+  "package": "com.theishiopian.parrying.CoreMod.Mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "parrying.refmap.json",
   "injectors": {
     "defaultRequire": 1
   },
   "minVersion": "0.8",
-  "plugin": "com.theishiopian.parrying.Mixin.ParryingMixinPlugin"
+  "plugin": "com.theishiopian.parrying.CoreMod.Mixin.ParryingMixinPlugin"
 }


### PR DESCRIPTION
sup bitch

As discussed in VC, coremodding can be very dangerous. One if the biggest dangers to coremods are other coremods, since they rely on the transformer to look for specific instructions *that might have already been transformed.* The easiest way to mitigate this is to isolate coremod logic.

What I mean by isolate coremod logic is to take most of the logic presented by the coremod and move it into a helper method or class. In doing this, we eliminate adding excess bytecode to the class and keep our code clean by organizing where most of the logic is contained.